### PR TITLE
use user's preferred endpoint

### DIFF
--- a/IndieAuth.php
+++ b/IndieAuth.php
@@ -225,7 +225,7 @@ class IndieAuthPlugin extends AuthPlugin {
         $auth_endpoint = $matches[1];
       }
       else {
-        preg_match('/<link\s+rel=["\']token_endpoint["\']\s+href=["\']([^"\']*)["\']/i', $result, $matches);
+        preg_match('/<link\s+rel=["\']authorization_endpoint["\']\s+href=["\']([^"\']*)["\']/i', $result, $matches);
         if(!empty($matches)){
           $auth_endpoint = $matches[1];
         }


### PR DESCRIPTION
This adds back the wordpress authorize function.  This function is needed as a place to fetch the user's auth endpoint.  Once this is found it stores it in to the session.  If no endpoints are found, it defaults to indieauth.com
